### PR TITLE
feat: delete collection

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 1.2.0 (2024-??-??)
+## 1.2.0 (2024-02-05)
 
+- Support collection deletion `operation:DELETE_COLLECTION` (and rollback)
 - Spot and show warnings if a non idempotent and deterministic update is spotted _(likely 2 scripts share the same id)_
 
 ## 1.1.0 (2024-01-08)

--- a/README.md
+++ b/README.md
@@ -199,6 +199,23 @@ new MongoBulkDataMigration<Score>({
 });
 ```
 
+### Delete a collection (`operation: DELETE_COLLECTION`)
+
+The collection will be renamed to the backup collection.
+When you rollback, the collection will simply be renamed back
+
+```ts
+import { MongoBulkDataMigration, DELETE_OPERATION } from "@360-l/mongo-bulk-data-migration";
+...
+const migration status = new MongoBulkDataMigration<Score>({
+    db,
+    id: "delete_collection_scores",
+    collectionName: "scores",
+    operation: DELETE_OPERATION,
+});
+console.log(status); // { ok: 1 }
+```
+
 ## 🧩 Ease testing
 
 MBDM provides to simplify your tests files. Just writes what you expect, and the util will ensure the database is back to initia state.

--- a/__tests__/MongoBulkDataMigration.test.ts
+++ b/__tests__/MongoBulkDataMigration.test.ts
@@ -1,7 +1,7 @@
-import { MongoError, MongoInvalidArgumentError } from 'mongodb';
+import { MongoError, MongoInvalidArgumentError, ObjectId } from 'mongodb';
 
 import type { Collection, Db } from 'mongodb';
-import { MongoBulkDataMigration } from '../src';
+import { MongoBulkDataMigration, DELETE_COLLECTION } from '../src';
 
 const COLLECTION = 'testCollection';
 const SCRIPT_ID = 'scriptId';
@@ -31,8 +31,16 @@ describe('MongoBulkDataMigration', () => {
   });
 
   afterEach(async () => {
-    await db.collection('testCollection').deleteMany({});
-    await db.collection('_rollback_testCollection_scriptId').deleteMany({});
+    try {
+      await db.dropCollection('testCollection');
+    } catch {
+      /* empty */
+    }
+    try {
+      await db.dropCollection('_rollback_testCollection_scriptId');
+    } catch {
+      /* empty */
+    }
   });
 
   it('should directly reject for invalid queries', async () => {
@@ -97,6 +105,74 @@ describe('MongoBulkDataMigration', () => {
         .listCollections({ name: '_rollback_testCollection_scriptId' })
         .toArray();
       expect(collections).toEqual([]);
+    });
+  });
+
+  describe('delete collection', () => {
+    const sampleDoc = { _id: new ObjectId(), test: 1 };
+    let migration: MongoBulkDataMigration<any>;
+    beforeEach(async () => {
+      migration = new MongoBulkDataMigration({
+        collectionName: COLLECTION,
+        db,
+        id: SCRIPT_ID,
+        operation: DELETE_COLLECTION,
+      });
+      await collection.insertMany([sampleDoc]);
+    });
+
+    it('should delete collection', async () => {
+      const updateStatus = await migration.update();
+
+      expect(updateStatus).toEqual({ ok: 1 });
+      const collections = await db
+        .listCollections({ name: '_rollback_testCollection_scriptId' })
+        .toArray();
+      expect(collections).toHaveLength(1);
+      const rollbackDocs = await db
+        .collection('_rollback_testCollection_scriptId')
+        .find({})
+        .toArray();
+      expect(JSON.stringify(rollbackDocs[0])).toEqual(
+        JSON.stringify(sampleDoc),
+      );
+    });
+
+    it('should be safe to run twice', async () => {
+      const updateStatus1 = await migration.update();
+      const updateStatus2 = await migration.update();
+
+      expect(updateStatus1).toEqual({ ok: 1 });
+      expect(updateStatus2).toEqual({ ok: 0 });
+    });
+
+    it('should rename backup collection', async () => {
+      await migration.update();
+
+      const rollbackStatus = await migration.rollback();
+
+      expect(rollbackStatus).toEqual({ ok: 1 });
+      const collections = await db
+        .listCollections({ name: '_rollback_testCollection_scriptId' })
+        .toArray();
+      expect(collections).toEqual([]);
+      const rollbackDocs = await db
+        .collection('testCollection')
+        .find({})
+        .toArray();
+      expect(JSON.stringify(rollbackDocs[0])).toEqual(
+        JSON.stringify(sampleDoc),
+      );
+    });
+
+    it('should do nothing when it rollback twice', async () => {
+      await migration.update();
+
+      const rollbackStatus1 = await migration.rollback();
+      const rollbackStatus2 = await migration.rollback();
+
+      expect(rollbackStatus1).toEqual({ ok: 1 });
+      expect(rollbackStatus2).toEqual({ ok: 0 });
     });
   });
 });

--- a/__tests__/how-to-release.md
+++ b/__tests__/how-to-release.md
@@ -1,0 +1,5 @@
+
+```bash
+npm run build:release
+npm publish --access public
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -17,6 +17,7 @@ import type {
   RollbackDocument,
   RollBackUpdateObject,
   RollbackableUpdate,
+  DMInstanceSpecialOperation,
 } from './types';
 import type { BulkOperationResult } from './lib/AbstractBulkOperationResults';
 import type { DELETE_OPERATION } from './lib/MigrationBulk';
@@ -25,6 +26,8 @@ import type { Collection, ObjectId, WithId, Document } from 'mongodb';
 const DEFAULT_BULK_SIZE = 5000;
 const COUNT_TOO_LONG_WARNING_THRESHOLD_MS = 30000;
 const COLLECTION_VALIDATION_LEVEL = 'moderate';
+/** Fully delete collection, use with operation:DELETE_COLLECTION */
+export const DELETE_COLLECTION = Symbol();
 const defaultLogger = {
   info: (...args: unknown[]) => {
     if (process.env.NODE_ENV === 'test') {
@@ -69,9 +72,14 @@ export default class MongoBulkDataMigration<TSchema extends Document>
     this.collectionName = config.collectionName;
     Object.assign(this.options, { ...config.options });
 
-    const { db, rollback, query, update } = config;
-    const { projection } = config as DMInstanceFilter<TSchema>;
-    this.migrationInfos = { db, projection, rollback, query, update };
+    this.migrationInfos = {
+      db: config.db,
+      operation: (config as DMInstanceSpecialOperation<TSchema>).operation,
+      projection: (config as DMInstanceFilter<TSchema>).projection,
+      rollback: (config as DMInstanceFilter<TSchema>).rollback,
+      query: (config as DMInstanceFilter<TSchema>).query,
+      update: (config as DMInstanceFilter<TSchema>).update,
+    };
 
     this.logger = config.logger ?? defaultLogger;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { DELETE_OPERATION } from './lib/MigrationBulk';
+export { DELETE_COLLECTION } from './MongoBulkDataMigration';
 export { default as MongoBulkDataMigration } from './MongoBulkDataMigration';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import type {
   Document,
 } from 'mongodb';
 import type { DELETE_OPERATION } from './lib/MigrationBulk';
+import { DELETE_COLLECTION } from './MongoBulkDataMigration';
 
 export type DataMigrationOptions<TSchema> = {
   /** Disable document validation temporarily on the rollback process */
@@ -43,6 +44,7 @@ export type MongoPipeline = object[];
 
 export type MigrationInfos<TSchema extends Document> = {
   db: Db;
+  operation?: typeof DELETE_COLLECTION;
   projection: FindOptions<TSchema>['projection'];
   rollback?: (backup: RollbackDocument['backup']) => RollBackUpdateObject;
   query: Filter<TSchema> | MongoPipeline;
@@ -55,11 +57,19 @@ export type MigrationInfos<TSchema extends Document> = {
 };
 
 export type DataMigrationConfig<TSchema extends Document> =
+  | DMInstanceSpecialOperation<TSchema>
   | DMInstanceAggregate<TSchema>
   | DMInstanceFilter<TSchema>;
 
 type DMInstanceAggregate<TSchema> = DMInstanceBase<TSchema> & {
   query: MongoPipeline;
+};
+
+export type DMInstanceSpecialOperation<TSchema> = Pick<
+  DMInstanceBase<TSchema>,
+  'db' | 'id' | 'collectionName' | 'logger' | 'options'
+> & {
+  operation: typeof DELETE_COLLECTION;
 };
 
 export type DMInstanceFilter<TSchema extends Document> =


### PR DESCRIPTION
### Description
I introduced a dedicate new property
```ts
const migration = new MongoBulkDataMigration({
  collectionName: "...",
  db: ...,
  id: SCRIPT_ID,
  operation: DELETE_COLLECTION,
});

// interface is unchanged
migration.update();
migration.rollback();
```


Shipped in 1.2.0