### PR TITLE
fix: unset array not object

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,16 @@
     "prettier"
   ],
   "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_.+",
+        "caughtErrorsIgnorePattern": "^_.+",
+        "varsIgnorePattern": "^_.+",
+        "args": "after-used",
+        "ignoreRestSiblings": true
+      }
+    ],
     // The following rule is enabled only to supplement the inline suppression
     // examples, and because it is not a recommended rule, you should either
     // disable it, or understand what it enforces.

--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0 (2024-??-??)
+
+- Fix issue where unset arrays were not properly restored https://github.com/360Learning/mongo-bulk-data-migration/issues/3
+
 ## 1.2.0 (2024-02-05)
 
 - Support collection deletion `operation:DELETE_COLLECTION` (and rollback)

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -162,6 +162,23 @@ describe('MongoBulkDataMigration', () => {
       expect(restoredDocuments).toEqual(insertedDocuments);
     });
 
+    it('should restore a property (array value) removed during migration', async () => {
+      await collection.insertMany([{ keys: [1, 2, 3] }]);
+      const dataMigration = new MongoBulkDataMigration({
+        ...DM_DEFAULT_SETUP,
+        projection: { keys: 1 },
+        update: { $unset: { keys: 1 } },
+      });
+      await dataMigration.update();
+
+      await dataMigration.rollback();
+
+      const restoredDocuments = await collection.find().toArray();
+      expect(restoredDocuments.map((doc) => _.omit(doc, '_id'))).toEqual([
+        { keys: [1, 2, 3] },
+      ]);
+    });
+
     it('should restore to the original deep structure', async () => {
       const insertResult = await collection.insertMany([
         {

--- a/__tests__/lib/computeRollbackQuery.unit.ts
+++ b/__tests__/lib/computeRollbackQuery.unit.ts
@@ -56,6 +56,32 @@ describe('computeRollbackQuery', () => {
         });
       });
 
+      it('should $set an original array value', async () => {
+        const updateQuery = { $unset: { key: 1 } };
+        const backup = { keys: ['value1', 'value2'] };
+
+        const restoreQuery = computeRollbackQuery(updateQuery, backup);
+
+        expect(restoreQuery).toEqual({
+          $set: { keys: ['value1', 'value2'] },
+        });
+      });
+
+      it('should $set an original deep array value', async () => {
+        const updateQuery = { $unset: { 'deep.key': 1 } };
+        const backup = {
+          deep: {
+            keys: ['value1', 'value2'],
+          },
+        };
+
+        const restoreQuery = computeRollbackQuery(updateQuery, backup);
+
+        expect(restoreQuery).toEqual({
+          $set: { 'deep.keys': ['value1', 'value2'] },
+        });
+      });
+
       it('should $set a nested value', async () => {
         const updateQuery = { $unset: { 'nested.key': 1 } };
         const backup = { nested: { key: 'value' } };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@360-l/mongo-bulk-data-migration",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -29,9 +29,25 @@ function computeRollbackSet(
       );
       if (parentKeyToFullyRestore) {
         rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
-      } else {
-        rollbackSet[key] = value;
+        return rollbackSet;
       }
+
+      const indexMatch = /(.*)\.(\d+)$/.exec(key);
+      if (indexMatch) {
+        const [_str, nestedPathToArray, index] = indexMatch;
+        if (Array.isArray(_.get(backup, nestedPathToArray))) {
+          if (typeof rollbackSet[nestedPathToArray] === 'undefined') {
+            rollbackSet[nestedPathToArray] = [];
+          }
+          rollbackSet[nestedPathToArray][Number(index)] = value;
+          return rollbackSet;
+        }
+
+        rollbackSet[nestedPathToArray] = value;
+        return rollbackSet;
+      }
+
+      rollbackSet[key] = value;
       return rollbackSet;
     },
     {} as any,


### PR DESCRIPTION
## Summary

### Reproduce the issue
- For a document
```js
{
  my: {
    keys: ["value1", "value2", ...]
  }
}
```

- With update query
```js
{
  $unset: { "my.keys": 1 }
}
```

To `$set` back value, we flatten all values. For arrays, we had an obvious bug when flattening paths:

```js
{
  $set: {
    "my.keys.0": "value1",
    "my.keys.1": "value2",
    ...
  }
}
```

### Fix behavior
When the backup prop is an **array**, we will as expected end up to
```ts
{
  $set: {
    "my.keys": ["value1", "value2", ...],
  }
}
```