### PR TITLE
fix: don't use upsert() when doing a rollback

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     // disable it, or understand what it enforces.
     // https://typescript-eslint.io/rules/explicit-function-return-type/
     "@typescript-eslint/explicit-function-return-type": "warn",
-    "@typescript-eslint/no-explicit-any": "warn"
+    "@typescript-eslint/no-explicit-any": "warn",
+    "no-console": "error"
   }
 }

--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0 (2024-02-15)
+
+- Don't use upsert() for rollback, instead call insert() for deleted documents to ease shard compliancy https://github.com/360Learning/mongo-bulk-data-migration/issues/5
+
 ## 1.3.0 (2024-02-13)
 
 - Fix issue where unset arrays were not properly restored https://github.com/360Learning/mongo-bulk-data-migration/issues/3

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -230,8 +230,10 @@ describe('MongoBulkDataMigration', () => {
       });
       expect(rollbackResults).toEqual({
         ...INITIAL_BULK_INFOS,
-        upserted: [insertedDocuments[1]._id],
-        nUpserted: 1,
+        insertedIds: [insertedDocuments[1]._id],
+        upserted: [],
+        nInserted: 1,
+        nUpserted: 0,
       });
       expect(restoredDocuments).toEqual(insertedDocuments);
     });

--- a/__tests__/how-to-release.md
+++ b/__tests__/how-to-release.md
@@ -1,4 +1,3 @@
-
 ```bash
 npm run build:release
 npm publish --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/RollbackBulk.ts
+++ b/src/lib/RollbackBulk.ts
@@ -16,7 +16,13 @@ export class RollbackBulk<
 
   public addRollbackOperation(operation: any, objectId: ObjectId): this {
     this.totalBulkOps++;
-    this.bulk.find({ _id: objectId }).upsert().update(operation);
+    this.bulk.find({ _id: objectId }).update(operation);
+    return this;
+  }
+
+  public addRollbackFullDocumentOperation(document: any): this {
+    this.totalBulkOps++;
+    this.bulk.insert(document);
     return this;
   }
 }


### PR DESCRIPTION
Fixes #5

We used to call upsert() for rollback.
- This is making rollback on sharded collection harder
- also, this can  behave unexpected: a docuement dropped in-between the update and rollback would be upserted