### PR TITLE
type: allow projection to not be set when using `DELETE_OPERATION`

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1 (2024-05-03)
+
+- Make `projection` not mandatory in typing when using `DELETE_OPERATION`
+
 ## 1.4.0 (2024-02-15)
 
 - Don't use upsert() for rollback, instead call insert() for deleted documents to ease shard compliancy https://github.com/360Learning/mongo-bulk-data-migration/issues/5

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -392,7 +392,7 @@ describe('MongoBulkDataMigration', () => {
     it('should perform the delete operation', async () => {
       await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
       const dataMigration = new MongoBulkDataMigration({
-        ...DM_DEFAULT_SETUP,
+        ..._.omit(DM_DEFAULT_SETUP, "projection"),
         query: { key: 2 },
         update: DELETE_OPERATION,
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,8 +58,14 @@ export type MigrationInfos<TSchema extends Document> = {
 
 export type DataMigrationConfig<TSchema extends Document> =
   | DMInstanceSpecialOperation<TSchema>
+  | DMInstanceSpecialOperationDropDocument<TSchema>
   | DMInstanceAggregate<TSchema>
-  | DMInstanceFilter<TSchema>;
+  | DMInstanceFilter<TSchema>
+  ;
+
+type DMInstanceSpecialOperationDropDocument<TSchema> = Omit<DMInstanceFilter<TSchema>, "projection"> & {
+  update: typeof DELETE_OPERATION
+}
 
 type DMInstanceAggregate<TSchema> = DMInstanceBase<TSchema> & {
   query: MongoPipeline;


### PR DESCRIPTION
### Description
As suggested by @LucVidal360 in a private repo.

When using `DELETE_OPERATION` (that deletes a document), we are force to specify the `projection` property otherwise TS yells:
![Screenshot from 2024-05-03 15-15-04](https://github.com/360Learning/mongo-bulk-data-migration/assets/572334/1cec9b42-e63b-44d8-958c-3f059483114f)

This is useless as the only possibility is `projection: {}` or `projection: undefined` i.e. empty projection to be able to fully restore the doc in the auto-rollback.

### Changes
I'm not narrowing the typing to make this a **patch** code update
Devs are now allowed to not define `projection` prop as expected.