### PR TITLE
feat: add option `rollbackable`

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.2 (2024-05-22)
+
+- Add the option `rollbackable` that is faster for update-only scripts
+  - Its default value is `true`
+  - When set to `false`, calling `update` will not inserted any document in the rollback collection
+  - When set to `false`, calling `rollback` will not do anything
+
 ## 1.4.1 (2024-05-03)
 
 - Make `projection` not mandatory in typing when using `DELETE_OPERATION`

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -637,23 +637,21 @@ describe('MongoBulkDataMigration', () => {
     });
 
     describe('options.rollbackable set to false', () => {
-      it('should be rollbackable using a rollback query with no param', async () => {
-        const insertResult = await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 2 }]);
-        const insertedDocuments = await collection
-          .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-          .toArray();
+      it('should not rollback anything', async () => {
+        await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 2 }]);
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           options: { rollbackable: false },
-          update: { $set: { value: 10 }},
-          rollback: () => ({ $unset: { value: 1 }})
+          update: { $set: { value: 10 }}
         });
 
         await dataMigration.update();
         await dataMigration.rollback();
         
-        const restoredDocuments = await collection.find().toArray();
-        expect(restoredDocuments).toEqual(insertedDocuments);
+        const updatedDocuments = await collection
+          .find({}, { projection: { _id: 0 } })
+          .toArray();
+        expect(updatedDocuments).toEqual([{ key: 1, value:10 }, { key: 2, value: 10 }, { key: 2, value: 10 }]);
       });
     });
   });

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -642,16 +642,20 @@ describe('MongoBulkDataMigration', () => {
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           options: { rollbackable: false },
-          update: { $set: { value: 10 }}
+          update: { $set: { value: 10 } },
         });
 
         await dataMigration.update();
         await dataMigration.rollback();
-        
+
         const updatedDocuments = await collection
           .find({}, { projection: { _id: 0 } })
           .toArray();
-        expect(updatedDocuments).toEqual([{ key: 1, value:10 }, { key: 2, value: 10 }, { key: 2, value: 10 }]);
+        expect(updatedDocuments).toEqual([
+          { key: 1, value: 10 },
+          { key: 2, value: 10 },
+          { key: 2, value: 10 },
+        ]);
       });
     });
   });

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -636,7 +636,7 @@ describe('MongoBulkDataMigration', () => {
       });
     });
 
-    describe('options.noBackup set to true', () => {
+    describe('options.rollbackable set to false', () => {
       it('should be rollbackable using a rollback query with no param', async () => {
         const insertResult = await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 2 }]);
         const insertedDocuments = await collection
@@ -644,7 +644,7 @@ describe('MongoBulkDataMigration', () => {
           .toArray();
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
-          options: { noBackup: true },
+          options: { rollbackable: false },
           update: { $set: { value: 10 }},
           rollback: () => ({ $unset: { value: 1 }})
         });

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -386,6 +386,22 @@ describe('MongoBulkDataMigration', () => {
         );
       });
     });
+
+    describe('options.noBackup set to true', () => {
+      it('should not insert any backup documents', async () => {
+        await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 2 }]);
+        const dataMigration = new MongoBulkDataMigration<Document>({
+          ...DM_DEFAULT_SETUP,
+          options: { noBackup: true },
+          update: { $set: { value: 10 }}
+        });
+
+        await dataMigration.update();
+        
+        const rollbackCollectionSize = await rollbackCollection.count();
+        expect(rollbackCollectionSize).toEqual(0);
+      });
+    })
   });
 
   describe('#delete', () => {

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -393,22 +393,22 @@ describe('MongoBulkDataMigration', () => {
         const dataMigration = new MongoBulkDataMigration<Document>({
           ...DM_DEFAULT_SETUP,
           options: { rollbackable: false },
-          update: { $set: { value: 10 }}
+          update: { $set: { value: 10 } },
         });
 
         await dataMigration.update();
-        
+
         const rollbackCollectionSize = await rollbackCollection.count();
         expect(rollbackCollectionSize).toEqual(0);
       });
-    })
+    });
   });
 
   describe('#delete', () => {
     it('should perform the delete operation', async () => {
       await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
       const dataMigration = new MongoBulkDataMigration({
-        ..._.omit(DM_DEFAULT_SETUP, "projection"),
+        ..._.omit(DM_DEFAULT_SETUP, 'projection'),
         query: { key: 2 },
         update: DELETE_OPERATION,
       });

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -387,12 +387,12 @@ describe('MongoBulkDataMigration', () => {
       });
     });
 
-    describe('options.noBackup set to true', () => {
+    describe('options.rollbackable set to false', () => {
       it('should not insert any backup documents', async () => {
         await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 2 }]);
         const dataMigration = new MongoBulkDataMigration<Document>({
           ...DM_DEFAULT_SETUP,
-          options: { noBackup: true },
+          options: { rollbackable: false },
           update: { $set: { value: 10 }}
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@360-l/mongo-bulk-data-migration",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -286,6 +286,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
 
   async rollback(): Promise<BulkOperationResult> {
     if (!this.options.rollbackable) {
+      this.logger.warn('Calling rollback() on a non rollbackable script');
       return { ok: 1 } as any;
     }
 

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -285,6 +285,8 @@ export default class MongoBulkDataMigration<TSchema extends Document>
   }
 
   async rollback(): Promise<BulkOperationResult> {
+    if(! this.options.rollbackable) { return { ok: 1 } as any; }
+
     const collection = this.getCollection();
     const rollbackCollection = await this.getRollbackCollection();
     if (this.migrationInfos.operation === DELETE_COLLECTION) {
@@ -293,22 +295,6 @@ export default class MongoBulkDataMigration<TSchema extends Document>
         this.collectionName,
       );
       return { ok: status ? 1 : 0 } as any;
-    }
-
-    if(! this.options.rollbackable) {
-      const result = await collection.updateMany({}, this.migrationInfos.rollback());
-      return {
-        ok: result.acknowledged ? 1 : 0,
-        insertedIds:  [],
-        nInserted: 0,
-        nMatched: result.matchedCount,
-        nModified: result.modifiedCount,
-        nRemoved: 0,
-        nUpserted: 0,
-        upserted: [],
-        writeConcernErrors: [],
-        writeErrors: [],
-      }
     }
 
     const cursor = rollbackCollection.find({});

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -53,7 +53,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
     dontCount: false,
     maxBulkSize: DEFAULT_BULK_SIZE,
     maxConcurrentUpdateCalls: 10,
-    noBackup: false,
+    rollbackable: true,
     throttle: 0,
   };
 
@@ -247,7 +247,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
         ? await this.migrationInfos.update(_.cloneDeep(document))
         : this.migrationInfos.update;
 
-      if(! this.options.noBackup) {
+      if(this.options.rollbackable) {
         const backupDocument = this.buildBackupDocument(
           document,
           updateQuery as MigrationInfos<TSchema>['update'],
@@ -295,7 +295,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
       return { ok: status ? 1 : 0 } as any;
     }
 
-    if(this.options.noBackup) {
+    if(! this.options.rollbackable) {
       const result = await collection.updateMany({}, this.migrationInfos.rollback());
       return {
         ok: result.acknowledged ? 1 : 0,

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -247,7 +247,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
         ? await this.migrationInfos.update(_.cloneDeep(document))
         : this.migrationInfos.update;
 
-      if(this.options.rollbackable) {
+      if (this.options.rollbackable) {
         const backupDocument = this.buildBackupDocument(
           document,
           updateQuery as MigrationInfos<TSchema>['update'],
@@ -285,7 +285,9 @@ export default class MongoBulkDataMigration<TSchema extends Document>
   }
 
   async rollback(): Promise<BulkOperationResult> {
-    if(! this.options.rollbackable) { return { ok: 1 } as any; }
+    if (!this.options.rollbackable) {
+      return { ok: 1 } as any;
+    }
 
     const collection = this.getCollection();
     const rollbackCollection = await this.getRollbackCollection();

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,10 +22,10 @@ export type DataMigrationOptions<TSchema> = {
   maxBulkSize: number;
   /** Maximum of update function called simultaneously */
   maxConcurrentUpdateCalls: number;
-  /** Deactivate the automatic backup logic */
-  noBackup: boolean;
   /** Restricted projection which will be backed up - use this if you need all `projection` keys to compute the update, but you are editing a subset */
   projectionBackupFilter?: Array<keyof TSchema>;
+  /** Keep the automatic rollback logic */
+  rollbackable: boolean;
   /** Idle time (in ms) after a bulk write - use this to decrease Database resource usage */
   throttle: number;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export type DataMigrationOptions<TSchema> = {
   maxBulkSize: number;
   /** Maximum of update function called simultaneously */
   maxConcurrentUpdateCalls: number;
+  /** Deactivate the automatic backup logic */
+  noBackup: boolean;
   /** Restricted projection which will be backed up - use this if you need all `projection` keys to compute the update, but you are editing a subset */
   projectionBackupFilter?: Array<keyof TSchema>;
   /** Idle time (in ms) after a bulk write - use this to decrease Database resource usage */
@@ -46,7 +48,7 @@ export type MigrationInfos<TSchema extends Document> = {
   db: Db;
   operation?: typeof DELETE_COLLECTION;
   projection: FindOptions<TSchema>['projection'];
-  rollback?: (backup: RollbackDocument['backup']) => RollBackUpdateObject;
+  rollback?: (backup?: RollbackDocument['backup']) => RollBackUpdateObject;
   query: Filter<TSchema> | MongoPipeline;
   update:
     | UpdateFilter<TSchema>

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,12 +62,14 @@ export type DataMigrationConfig<TSchema extends Document> =
   | DMInstanceSpecialOperation<TSchema>
   | DMInstanceSpecialOperationDropDocument<TSchema>
   | DMInstanceAggregate<TSchema>
-  | DMInstanceFilter<TSchema>
-  ;
+  | DMInstanceFilter<TSchema>;
 
-type DMInstanceSpecialOperationDropDocument<TSchema> = Omit<DMInstanceFilter<TSchema>, "projection"> & {
-  update: typeof DELETE_OPERATION
-}
+type DMInstanceSpecialOperationDropDocument<TSchema> = Omit<
+  DMInstanceFilter<TSchema>,
+  'projection'
+> & {
+  update: typeof DELETE_OPERATION;
+};
 
 type DMInstanceAggregate<TSchema> = DMInstanceBase<TSchema> & {
   query: MongoPipeline;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type DataMigrationOptions<TSchema> = {
   maxConcurrentUpdateCalls: number;
   /** Restricted projection which will be backed up - use this if you need all `projection` keys to compute the update, but you are editing a subset */
   projectionBackupFilter?: Array<keyof TSchema>;
-  /** Keep the automatic rollback logic */
+  /** When off, won't backup document and will silently do nothing at rollback procedure */
   rollbackable: boolean;
   /** Idle time (in ms) after a bulk write - use this to decrease Database resource usage */
   throttle: number;


### PR DESCRIPTION
### Context

Issue: https://github.com/360Learning/platform/issues/48689

In some situations, we would prefer to bypass the automatic backup logic to speed up the scripts.

Example:
- add a new optional field in the collection
- initialize the value of the field using MBDM
- the rollback script update is an `$unset` of the field on the whole collection
- having the whole backup logic on update and rollback doubles the number of interactions with the database for nothing

### Changes

This PR is about adding a `noBackup` option that bypasses the backup logic.

### Trade-offs

- the `rollback` field is now mandatory to be able to perform a `backup`
- the `rollback` function will always be passed a param undefined, indeed, there is no proper source document in the backup

I assumed these constraints were obvious.
Like the constraint that says that the param in the `rollback` function is limited to the fields projected during the backup.
It is not enforced in types, as I did not find a way to do it without adding too much complexity. :/ 