### PR TITLE
doc: fix `README.md` aggregation documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ new MongoBulkDataMigration<Score>({
         { $match: { "games.value": "xxx" } },
     ],
     update: (doc) => ({
-        ...doc,
-        totalGames: doc.games.value
+        $set: {
+          totalGames: doc.games.value
+        }
     }),
     options: {
         projectionBackupFilter: ["totalGames"] // Necessary to save only totalGames, not games.value in the backup document

--- a/README.md
+++ b/README.md
@@ -191,11 +191,12 @@ new MongoBulkDataMigration<Score>({
     ],
     update: (doc) => ({
         $set: {
-          totalGames: doc.games.value
+            totalGames: doc.games.value
         }
     }),
     options: {
-        projectionBackupFilter: ["totalGames"] // Necessary to save only totalGames, not games.value in the backup document
+        // Necessary to save only `totalGames`, and not auto-restore uncexisting `games` field
+        projectionBackupFilter: ["totalGames"]
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ new MongoBulkDataMigration<Score>({
     id: "delete_negative_total",
     collectionName: "scores",
     query: [
-        { $lookup: { localField: "games", ... } },
+        { $lookup: { as: "games", ... } },
         { $match: { "games.value": "xxx" } },
         { $project: { "games.value": 1, totalGames: 1, _id: 1 } },
     },

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ new MongoBulkDataMigration<Score>({
     db,
     id: "delete_negative_total",
     collectionName: "scores",
+    projection: { "games.value": 1, totalGames: 1 },
     query: [
         { $lookup: { as: "games", ... } },
         { $match: { "games.value": "xxx" } },
-        { $project: { "games.value": 1, totalGames: 1, _id: 1 } },
-    },
+    ],
     update: (doc) => ({
         ...doc,
         totalGames: doc.games.value


### PR DESCRIPTION
### Summary

This PR fixes:
- misleading `localField` lookup, replaced by `as`
- incorrect query closing bracket `}`, replaced by `]`
- incorrect update returning the updated document, replaced by Mongo update filter

Enhancement:
- move projection outside aggregation pipeline to `MongoBulkDataMigration` properties, for consistency