### PR TITLE
fix: fix errors when `rollbackable` is `false`

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3 (2024-09-10)
+
+- Fix issues when the option `rollbackable` is `false`
+  - Correctly compute bulk size, to decide when executing it
+  - Do not warn because the number of rollback documents is 0
+
 ## 1.4.2 (2024-05-22)
 
 - Add the option `rollbackable` that is faster for update-only scripts

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import type { Collection, Db, Document, ObjectId } from 'mongodb';
 import { MongoBulkDataMigration, DELETE_OPERATION } from '../src';
 import { INITIAL_BULK_INFOS } from '../src/lib/AbstractBulkOperationResults';
+import { LoggerInterface } from '../src/types';
+
 
 const COLLECTION = 'testCollection';
 const SCRIPT_ID = 'scriptId';
@@ -15,6 +17,7 @@ describe('MongoBulkDataMigration', () => {
     db: Db;
     id: string;
     query: any;
+    logger: LoggerInterface;
     projection: any;
   };
 
@@ -22,14 +25,20 @@ describe('MongoBulkDataMigration', () => {
     db = global.db;
     collection = db.collection(COLLECTION);
     rollbackCollection = db.collection('_rollback_testCollection_scriptId');
+    loggerMock = {
+      info: jest.fn(),
+      warn: jest.fn(),
+    };
     DM_DEFAULT_SETUP = {
       collectionName: COLLECTION,
       db,
       id: SCRIPT_ID,
       query: {},
+      logger: loggerMock,
       projection: {},
     };
   });
+  let loggerMock: LoggerInterface;
 
   afterEach(async () => {
     await db.collection('testCollection').deleteMany({});
@@ -400,6 +409,7 @@ describe('MongoBulkDataMigration', () => {
 
         const rollbackCollectionSize = await rollbackCollection.count();
         expect(rollbackCollectionSize).toEqual(0);
+        expect(loggerMock.warn).not.toHaveBeenCalled();
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@360-l/mongo-bulk-data-migration",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -165,13 +165,15 @@ export default class MongoBulkDataMigration<TSchema extends Document>
           await bulkMigration.execute(this.options.continueOnBulkWriteError)
         ).getResults();
 
-        const totalNewBackupDocs = backupRes.nUpserted + backupRes.nInserted;
-        const totalUpdatedDocument = updateRes.nModified + updateRes.nRemoved;
-        if (totalNewBackupDocs < totalUpdatedDocument) {
-          this.logger.warn(
-            { totalNewBackupDocs, totalUpdatedDocument },
-            "The number of backup documents should be equal to the total updated documents. Check your query is idempotent or ensure you don't use a same migration id for different migrations.",
-          );
+        if (this.options.rollbackable) {
+          const totalNewBackupDocs = backupRes.nUpserted + backupRes.nInserted;
+          const totalUpdatedDocument = updateRes.nModified + updateRes.nRemoved;
+          if (totalNewBackupDocs < totalUpdatedDocument) {
+            this.logger.warn(
+              { totalNewBackupDocs, totalUpdatedDocument },
+              "The number of backup documents should be equal to the total updated documents. Check your query is idempotent or ensure you don't use a same migration id for different migrations.",
+            );
+          }
         }
 
         await this.throttle();

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -122,9 +122,8 @@ export default class MongoBulkDataMigration<TSchema extends Document>
     }
 
     await this.lowerValidationLevel('update');
-    const { cursor, totalEntries } = await this.getCursorAndCount(
-      migrationCollection,
-    );
+    const { cursor, totalEntries } =
+      await this.getCursorAndCount(migrationCollection);
     const formattedTotalEntries =
       totalEntries === NO_COUNT_AVAILABLE
         ? 'N/A (dontCount option ON)'

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -158,11 +158,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
       updatePromises.push(bulkUpdateWrappedPromise);
 
       document = (await cursor.next()) as WithId<TSchema> | null;
-      const totalIncludingPendingBulks =
-        bulkBackup.size +
-        updatePromiseLimiter.activeCount +
-        updatePromiseLimiter.pendingCount;
-      if (!document || totalIncludingPendingBulks >= this.options.maxBulkSize) {
+      if (!document || updatePromises.length >= this.options.maxBulkSize) {
         await Promise.all(updatePromises);
         const backupRes = (await bulkBackup.execute()).getResults();
         const updateRes = (


### PR DESCRIPTION
### Context

Initial PR: #8 

The PR #8 introduced a new option: `rollbackable`.
Unfortunately, this causes a few wrong behavior when it's set to `false`.

- the amount of document stored in a bulk is wrongly computed
  - indeed, it was based on the amount of rollback documents created
  - in case of very fast bulk operation creation, this can lead to high memory consumption
- for every bulk execution, we get the warning:
  - "The number of backup documents should be equal to the total updated documents"

### Changes

- Fix the amount of document stored in a bulk
- Do not verify number of backup documents created when `rollbackable` is `false`.
