### PR TITLE
fix: makes rollback handle nested array values

### DIFF
--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -393,6 +393,25 @@ describe('MongoBulkDataMigration', () => {
         expect(restoredDocuments).toEqual([sampleDocument]);
       });
 
+      it('should restore nested array values', async () => {
+        const document = {
+          nested: {
+            array: ["a", "b"],
+          }
+        }
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $set: { "nested.array": ["c"] } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual([document]);
+      });
+
       it('should not restore non-projected sibling values', async () => {
         const { insertedIds } = await collection.insertMany([sampleDocument]);
         const dataMigration = new MongoBulkDataMigration({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -24,14 +24,6 @@ function computeRollbackSet(
 
   return Object.entries(flattenBackupDocument).reduce(
     (rollbackSet, [key, value]) => {
-      const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
-        (userSet) => key.startsWith(`${userSet}.`),
-      );
-      if (parentKeyToFullyRestore) {
-        rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
-        return rollbackSet;
-      }
-
       const indexMatch = /(.*)\.(\d+)$/.exec(key);
       if (indexMatch) {
         const [_str, nestedPathToArray, index] = indexMatch;
@@ -44,6 +36,14 @@ function computeRollbackSet(
         }
 
         rollbackSet[nestedPathToArray] = value;
+        return rollbackSet;
+      }
+
+      const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
+        (userSet) => key.startsWith(`${userSet}.`),
+      );
+      if (parentKeyToFullyRestore) {
+        rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
         return rollbackSet;
       }
 


### PR DESCRIPTION
Issue: #14

Nested arrays are not rollbacked successfully: their values will be lost.

Example:

```js
{
    nested: {
        array: ["a", "b"],
    }
}
```

The issue comes from the fact that

```ts
const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
  (userSet) => key.startsWith(`${userSet}.`),
);
if (parentKeyToFullyRestore) {
  rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
  return rollbackSet;
}
```

was taking precedence over the array-checking code block.

We now do the `const indexMatch = /(.*)\.(\d+)$/.exec(key);` check first.

### Changes

- Adds a failing test: `should restore nested array values`.
- Fixes the bug.