### PR TITLE
fix(#17): handles array elements having objects

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.5 (2024-10-28)
+
+- Patch 1.4.4 regression for auto rollback on nested properties
+
 ## 1.4.4 (2024-10-23)
 
 - Fix bug: rollback in nested properties didn't work for array values (`$set:{"a.b":[...]}`)

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -412,6 +412,29 @@ describe('MongoBulkDataMigration', () => {
         expect(restoredDocuments).toEqual([document]);
       });
 
+      it('should restore an array element having objects', async () => {
+        const document = {
+          array: [
+            {
+              nested: [
+                "nestedValue"
+              ]
+            }
+          ]
+        }
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $set: { array: [] } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual([document]);
+      });
+
       it('should not restore non-projected sibling values', async () => {
         const { insertedIds } = await collection.insertMany([sampleDocument]);
         const dataMigration = new MongoBulkDataMigration({

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -416,12 +416,10 @@ describe('MongoBulkDataMigration', () => {
         const document = {
           array: [
             {
-              nested: [
-                "nestedValue"
-              ]
-            }
-          ]
-        }
+              nested: ['nestedValue'],
+            },
+          ],
+        };
         await collection.insertMany([document]);
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -24,6 +24,14 @@ function computeRollbackSet(
 
   return Object.entries(flattenBackupDocument).reduce(
     (rollbackSet, [key, value]) => {
+      const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
+        (userSet) => key.startsWith(`${userSet}.`),
+      );
+      if (parentKeyToFullyRestore && parentKeyToFullyRestore in backup) {
+        rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
+        return rollbackSet;
+      }
+
       const indexMatch = /(.*)\.(\d+)$/.exec(key);
       if (indexMatch) {
         const [_str, nestedPathToArray, index] = indexMatch;
@@ -36,14 +44,6 @@ function computeRollbackSet(
         }
 
         rollbackSet[nestedPathToArray] = value;
-        return rollbackSet;
-      }
-
-      const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
-        (userSet) => key.startsWith(`${userSet}.`),
-      );
-      if (parentKeyToFullyRestore) {
-        rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
         return rollbackSet;
       }
 


### PR DESCRIPTION
Fixes #17.

### Changes 

- We are going back to what we were doing pre #15, except that on top of checking first.

```ts
const parentKeyToFullyRestore = setPropertiesDuringUpdate.find(
        (userSet) => key.startsWith(`${userSet}.`),
      );
      if (parentKeyToFullyRestore) {
        // ...
      }
```
I added `&& parentKeyToFullyRestore in backup` as well.

- Adds a test to cover this case.