### PR TITLE
test: add coverage for setting back value after  an `$unset` 

### DIFF
--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -383,7 +383,7 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-        
+
         expect(restoredDocuments).toEqual([document]);
       });
 
@@ -399,7 +399,56 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-        
+
+        expect(restoredDocuments).toEqual([document]);
+      });
+
+      it('should restore a nested object value', async () => {
+        const document = { deep: { key: 'value' } };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { 'deep.key': 1 } },
+          projection: { deep: 1 },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+
+        expect(restoredDocuments).toEqual([document]);
+      });
+
+      it('should restore a nested object value even if key is not projected', async () => {
+        const document = { deep: { key: 'value' } };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { 'deep.key': 1 } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+
+        expect(restoredDocuments).toEqual([document]);
+      });
+
+      it('should restore a nested object value in array', async () => {
+        const document = { deep: { key: { 0: 'value' } } };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { 'deep.key.0': 1 } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+
         expect(restoredDocuments).toEqual([document]);
       });
     });

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -369,6 +369,41 @@ describe('MongoBulkDataMigration', () => {
       });
     });
 
+    describe('$unset support', () => {
+      it('should restore an object values', async () => {
+        const document = { key: 'value' };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { key: 1 } },
+          projection: { key: 1 },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        
+        expect(restoredDocuments).toEqual([document]);
+      });
+
+      it('should restore an object values even if key is not projected', async () => {
+        const document = { key: 'value' };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { key: 1 } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        
+        expect(restoredDocuments).toEqual([document]);
+      });
+    });
+
     describe('Number indexed objects support', () => {
       it('should restore an object with numbers as keys', async () => {
         const document = {


### PR DESCRIPTION
Issue: https://github.com/360Learning/mongo-bulk-data-migration/issues/10

### Summary
I just wanted to make sure `$unset` auto-rollback was working as expected

- Adding tests know rollback methods tests