### PR TITLE
feat(21): `arrayFilters` support with automatic rollback

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0-rc1 (2024-xx-yy)
 
+- Support for `arrayFilters`
 - Improve automatic rollback for nested paths - Thanks [@hugop95](https://github.com/hugop95) https://github.com/360Learning/mongo-bulk-data-migration/pull/19
 
 ## 1.4.5 (2024-10-28)

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -160,14 +160,12 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should restore a property removed during migration', async () => {
-      const insertResult = await collection.insertMany([
+      await collection.insertMany([
         { other: 1, key: 1 },
         { other: 1, key: 2 },
         { other: 1, key: 3 },
       ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      const insertedDocuments = await collection.find().toArray();
       const dataMigration = new MongoBulkDataMigration({
         ...DM_DEFAULT_SETUP,
         update: { $unset: { key: 1 } },
@@ -198,16 +196,14 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should restore to the original deep structure', async () => {
-      const insertResult = await collection.insertMany([
+      await collection.insertMany([
         {
           a: {
             b: 'value',
           },
         },
       ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      const insertedDocuments = await collection.find().toArray();
       const dataMigration = new MongoBulkDataMigration({
         ...DM_DEFAULT_SETUP,
         update: (doc: any) => ({ $set: { a: doc.a.b } }),
@@ -221,14 +217,8 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should restore removed documents', async () => {
-      const insertResult = await collection.insertMany([
-        { key: 1 },
-        { key: 2 },
-        { key: 3 },
-      ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
+      const insertedDocuments = await collection.find().toArray();
       const dataMigration = new MongoBulkDataMigration({
         ...DM_DEFAULT_SETUP,
         query: { key: 2 },
@@ -257,13 +247,8 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should remove properties added during migration', async () => {
-      const insertResult = await collection.insertMany([
-        { other: 1 },
-        { other: 1 },
-      ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      await collection.insertMany([{ other: 1 }, { other: 1 }]);
+      const insertedDocuments = await collection.find().toArray();
       const dataMigration = new MongoBulkDataMigration({
         ...DM_DEFAULT_SETUP,
         update: { $set: { key: 2 } },
@@ -692,14 +677,12 @@ describe('MongoBulkDataMigration', () => {
 
     describe('Aggregate support', () => {
       it('should perform rollback for an aggregate pipeline', async () => {
-        const insertResult = await collection.insertMany([
+        await collection.insertMany([
           { key: 1, letThis: true },
           { key: 1 },
           { key: 5 },
         ]);
-        const insertedDocuments = await collection
-          .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-          .toArray();
+        const insertedDocuments = await collection.find().toArray();
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           query: [
@@ -816,14 +799,12 @@ describe('MongoBulkDataMigration', () => {
 
     describe('With rollback function', () => {
       it('should apply a specific rollback operation and unset an added value', async () => {
-        const insertResult = await collection.insertMany([
+        await collection.insertMany([
           { other: 1, key: 1 },
           { other: 1, key: 2 },
           { other: 1, key: 3 },
         ]);
-        const insertedDocuments = await collection
-          .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-          .toArray();
+        const insertedDocuments = await collection.find().toArray();
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           options: { bypassRollbackValidation: true },
@@ -839,13 +820,11 @@ describe('MongoBulkDataMigration', () => {
       });
 
       it('should call the rollback function with the backup document', async () => {
-        const insertResult = await collection.insertMany([
+        await collection.insertMany([
           { value: 1, double: 2 },
           { value: 1, double: 2 },
         ]);
-        const insertedDocuments = await collection
-          .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-          .toArray();
+        const insertedDocuments = await collection.find().toArray();
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           rollback: (doc: any) => ({ $set: { double: doc.value * 2 } }),
@@ -913,13 +892,8 @@ describe('MongoBulkDataMigration', () => {
             },
           ],
         };
-        const insertResult = await collection.insertMany([
-          matchDocument,
-          fullyUnmatchedDocument,
-        ]);
-        const insertedDocuments = await collection
-          .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-          .toArray();
+        await collection.insertMany([matchDocument, fullyUnmatchedDocument]);
+        const insertedDocuments = await collection.find().toArray();
 
         const migration = new MongoBulkDataMigration<any>({
           ...DM_DEFAULT_SETUP,

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -66,14 +66,12 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should perform the migration successfully without changing other properties', async () => {
-      const insertResult = await collection.insertMany([
+      await collection.insertMany([
         { key: 1, other: 1 },
         { key: 2, other: 1 },
         { key: 3, other: 1 },
       ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      const insertedDocuments = await collection.find().toArray();
       const dataMigration = new MongoBulkDataMigration({
         ...DM_DEFAULT_SETUP,
         update: () => ({ $set: { key: 2 } }),
@@ -93,14 +91,8 @@ describe('MongoBulkDataMigration', () => {
     });
 
     it('should allow to continue a not ended migration', async () => {
-      const insertResult = await collection.insertMany([
-        { key: 1 },
-        { key: 2 },
-        { key: 3 },
-      ]);
-      const insertedDocuments = await collection
-        .find({ _id: { $in: Object.values(insertResult.insertedIds) } })
-        .toArray();
+      await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
+      const insertedDocuments = await collection.find().toArray();
       let updateStubRunCount = 0;
       const udpateStub = jest.fn().mockImplementation(() => {
         updateStubRunCount++;
@@ -476,7 +468,7 @@ describe('MongoBulkDataMigration', () => {
             subKey1: 'match_me',
             subKey2: [
               { elt1: 90 },
-              { elt1: 130 }, // <--- Only this element is matches (>=100)
+              { elt1: 130 }, // <--- Only this element matches (>=100)
             ],
           },
         ],

--- a/__tests__/lib/computeRollbackQuery.unit.ts
+++ b/__tests__/lib/computeRollbackQuery.unit.ts
@@ -154,4 +154,23 @@ describe('computeRollbackQuery', () => {
       });
     });
   });
+
+  describe('[with arrayFilters] $unset after having $set', () => {
+    it('should $unset an added value and generate arrayFilters', async () => {
+      const updateQuery = {
+        $set: {
+          'keys.$[element].key': 'update_value',
+        },
+      };
+
+      const restoreQuery = computeRollbackQuery(updateQuery, {});
+
+      expect(restoreQuery).toEqual({
+        $unset: {
+          'keys.$[element].key': 1,
+        },
+        arrayFilters: [{ 'element.key': { $exists: true } }],
+      });
+    });
+  });
 });

--- a/__tests__/tools/arrayFilter.unit.ts
+++ b/__tests__/tools/arrayFilter.unit.ts
@@ -1,5 +1,7 @@
 import {
   isArrayFilterPath,
+  hasPathMatchingPositionalOperators,
+  buildArrayFiltersOptionToUnset,
 } from '../../src/tools/arrayFilters';
 
 describe('utils/arrayFilters', () => {
@@ -12,6 +14,44 @@ describe('utils/arrayFilters', () => {
     it('returns true for path containing at least one positional operator', () => {
       expect(isArrayFilterPath('my.$[name_me].key')).toBe(true);
       expect(isArrayFilterPath('my.$[name_me1].to.$[name_me2].key')).toBe(true);
+    });
+  });
+
+  describe('#hasPathMatchingPositionalOperators', () => {
+    it('returns false if it does not match any path', () => {
+      const match = hasPathMatchingPositionalOperators(
+        'keys.$[element].subKey.$[element2].value',
+        ['keys.0.differentSubKey.0.value', 'keys.0.differentSubKey.1.value'],
+      );
+
+      expect(match).toBe(false);
+    });
+
+    it('returns true if the path with positional arguments matches any path in the list', () => {
+      const match = hasPathMatchingPositionalOperators(
+        'keys.$[element].subKey.$[element2].value',
+        [
+          'keys.0.subKey.0.value',
+          'keys.0.subKey.1.value',
+          'keys.1.subKey.0.value',
+          'keys.1.subKey.1.value',
+        ],
+      );
+
+      expect(match).toBe(true);
+    });
+  });
+
+  describe('#buildArrayFiltersOptionToUnset', () => {
+    it('returns the arrayFilter options for every positional arguments in the path', () => {
+      const options = buildArrayFiltersOptionToUnset(
+        'keys.$[element].subKey.$[element2].value',
+      );
+
+      expect(options).toEqual([
+        { 'element.subKey': { $exists: true } },
+        { 'element2.value': { $exists: true } },
+      ]);
     });
   });
 });

--- a/__tests__/tools/arrayFilter.unit.ts
+++ b/__tests__/tools/arrayFilter.unit.ts
@@ -1,0 +1,17 @@
+import {
+  isArrayFilterPath,
+} from '../../src/tools/arrayFilters';
+
+describe('utils/arrayFilters', () => {
+  describe('#isArrayFilterPath', () => {
+    it('returns false for a path not containing positional operator', () => {
+      expect(isArrayFilterPath('my.key')).toBe(false);
+      expect(isArrayFilterPath('some.weird.$.key')).toBe(false);
+    });
+
+    it('returns true for path containing at least one positional operator', () => {
+      expect(isArrayFilterPath('my.$[name_me].key')).toBe(true);
+      expect(isArrayFilterPath('my.$[name_me1].to.$[name_me2].key')).toBe(true);
+    });
+  });
+});

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -47,6 +47,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
   implements RollbackableUpdate
 {
   private readonly options: DataMigrationOptions<TSchema> = {
+    arrayFilters: [],
     bypassRollbackValidation: false,
     bypassUpdateValidation: false,
     continueOnBulkWriteError: false,
@@ -256,6 +257,7 @@ export default class MongoBulkDataMigration<TSchema extends Document>
       bulkMigration.addUpdateOrRemoveOperation(
         updateQuery,
         document._id as ObjectId,
+        this.options.arrayFilters,
       );
     };
   }

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -123,9 +123,8 @@ export default class MongoBulkDataMigration<TSchema extends Document>
     }
 
     await this.lowerValidationLevel('update');
-    const { cursor, totalEntries } = await this.getCursorAndCount(
-      migrationCollection,
-    );
+    const { cursor, totalEntries } =
+      await this.getCursorAndCount(migrationCollection);
     const formattedTotalEntries =
       totalEntries === NO_COUNT_AVAILABLE
         ? 'N/A (dontCount option ON)'
@@ -320,7 +319,12 @@ export default class MongoBulkDataMigration<TSchema extends Document>
       if (this.migrationInfos.update === DELETE_OPERATION) {
         bulkRollback.addRollbackFullDocumentOperation(rollbackDocument.backup);
       } else {
-        bulkRollback.addRollbackOperation(updateQuery, rollbackDocument._id);
+        const { arrayFilters, ...cleanedUpdateQuery } = updateQuery;
+        bulkRollback.addRollbackOperation(
+          cleanedUpdateQuery,
+          rollbackDocument._id,
+          arrayFilters ?? [],
+        );
       }
 
       rollbackDocument =

--- a/src/lib/MigrationBulk.ts
+++ b/src/lib/MigrationBulk.ts
@@ -19,19 +19,24 @@ export class MigrationBulk<
   public addUpdateOrRemoveOperation(
     updateQuery: UpdateFilter<TSchema> | typeof DELETE_OPERATION,
     objectId: ObjectId,
+    arrayFilters: Document[],
   ): this {
     if (updateQuery === DELETE_OPERATION) {
       return this.addRemoveOperation(objectId);
     }
-    return this.addUpdateOperation(updateQuery, objectId);
+    return this.addUpdateOperation(updateQuery, objectId, arrayFilters);
   }
 
   public addUpdateOperation(
     updateQuery: UpdateFilter<TSchema>,
     objectId: ObjectId,
+    arrayFilters: Document[],
   ): this {
     this.totalBulkOps++;
-    this.bulk.find({ _id: objectId }).update(updateQuery);
+    this.bulk
+      .find({ _id: objectId })
+      .arrayFilters(arrayFilters)
+      .update(updateQuery);
     return this;
   }
 

--- a/src/lib/MigrationBulk.ts
+++ b/src/lib/MigrationBulk.ts
@@ -33,10 +33,16 @@ export class MigrationBulk<
     arrayFilters: Document[],
   ): this {
     this.totalBulkOps++;
-    this.bulk
-      .find({ _id: objectId })
-      .arrayFilters(arrayFilters)
-      .update(updateQuery);
+
+    if (arrayFilters.length === 0) {
+      this.bulk.find({ _id: objectId }).update(updateQuery);
+    } else {
+      this.bulk
+        .find({ _id: objectId })
+        .arrayFilters(arrayFilters)
+        .update(updateQuery);
+    }
+
     return this;
   }
 

--- a/src/lib/RollbackBulk.ts
+++ b/src/lib/RollbackBulk.ts
@@ -20,10 +20,16 @@ export class RollbackBulk<
     arrayFilters: Document[],
   ): this {
     this.totalBulkOps++;
-    this.bulk
-      .find({ _id: objectId })
-      .arrayFilters(arrayFilters)
-      .update(operation);
+
+    if (arrayFilters.length === 0) {
+      this.bulk.find({ _id: objectId }).update(operation);
+    } else {
+      this.bulk
+        .find({ _id: objectId })
+        .arrayFilters(arrayFilters)
+        .update(operation);
+    }
+
     return this;
   }
 

--- a/src/lib/RollbackBulk.ts
+++ b/src/lib/RollbackBulk.ts
@@ -14,9 +14,16 @@ export class RollbackBulk<
     return this;
   }
 
-  public addRollbackOperation(operation: any, objectId: ObjectId): this {
+  public addRollbackOperation(
+    operation: any,
+    objectId: ObjectId,
+    arrayFilters: Document[],
+  ): this {
     this.totalBulkOps++;
-    this.bulk.find({ _id: objectId }).update(operation);
+    this.bulk
+      .find({ _id: objectId })
+      .arrayFilters(arrayFilters)
+      .update(operation);
     return this;
   }
 

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -43,9 +43,9 @@ function _computeArrayFilterAndUnsetWithPositionals(
   const arrayFilters: Document[] = [];
   const update = Object.keys(flattenDocument(updateQuery.$set ?? {}));
   update
-    .filter((path) => !filteredObject.includes(path))
     .filter(
       (path) =>
+        !filteredObject.includes(path) &&
         !arrayFiltersUtils.hasPathMatchingPositionalOperators(
           path,
           filteredObject,

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 import { flattenDocument } from '../tools/flattenDocument';
+import * as arrayFiltersUtils from '../tools/arrayFilters';
+import type { Document } from 'mongodb';
 
 /**
  * @param updateQuery Mongo update query executed at migration
@@ -8,11 +10,59 @@ import { flattenDocument } from '../tools/flattenDocument';
 export function computeRollbackQuery(updateQuery: any, backup: any) {
   const setPropertiesDuringUpdate = Object.keys(updateQuery.$set || {});
   const $set = computeRollbackSet(setPropertiesDuringUpdate, backup);
-  const $unset = computeRollbackUnset(setPropertiesDuringUpdate, backup, $set);
+  const $unsetWithoutPositionals = computeRollbackUnset(
+    setPropertiesDuringUpdate,
+    backup,
+    $set,
+  );
+
+  const { arrayFilters, unsetAdditionalPositional } =
+    _computeArrayFilterAndUnsetWithPositionals(updateQuery, backup);
+  const $unset = {
+    ...$unsetWithoutPositionals,
+    ...unsetAdditionalPositional,
+  };
 
   return {
     ...(!_.isEmpty($set) ? { $set } : {}),
     ...(!_.isEmpty($unset) ? { $unset } : {}),
+    ...(!_.isEmpty(arrayFilters) ? { arrayFilters } : {}),
+  };
+}
+
+/**
+ * If path contains a "positional argument", we'll have to add the correct
+ * arrayFilters options for the $unset operation to work correctly
+ */
+function _computeArrayFilterAndUnsetWithPositionals(
+  updateQuery: any,
+  backup: any,
+): { arrayFilters: Document[]; unsetAdditionalPositional: any } {
+  const unsetAdditionalPositional = {};
+  const filteredObject = Object.keys(flattenDocument(backup));
+  const arrayFilters: Document[] = [];
+  const update = Object.keys(flattenDocument(updateQuery.$set ?? {}));
+  update
+    .filter((path) => !filteredObject.includes(path))
+    .filter(
+      (path) =>
+        !arrayFiltersUtils.hasPathMatchingPositionalOperators(
+          path,
+          filteredObject,
+        ),
+    )
+    .forEach((path) => {
+      if (arrayFiltersUtils.isArrayFilterPath(path)) {
+        unsetAdditionalPositional[path] = 1;
+        arrayFilters.push(
+          ...arrayFiltersUtils.buildArrayFiltersOptionToUnset(path),
+        );
+      }
+    });
+
+  return {
+    arrayFilters,
+    unsetAdditionalPositional,
   };
 }
 
@@ -69,6 +119,7 @@ function computeRollbackUnset(
   const keysToUnset = setPropertiesDuringUpdate.filter(
     (path) =>
       !keysToSet.includes(path) &&
+      !arrayFiltersUtils.isArrayFilterPath(path) &&
       !keysToSet.some((key) => path.startsWith(`${key}.`)),
   );
   const parentKeysToUnset = computeParentKeysToUnset(keysToUnset, backup);

--- a/src/tools/arrayFilters.ts
+++ b/src/tools/arrayFilters.ts
@@ -1,0 +1,17 @@
+/**
+ * Spots "positional operator" path in string for array filters
+ * Example: xxx.$[element_name].yyy
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/update/positional-filtered/
+ */
+const ARRAY_FILTER_OPERATION_PATTERN = /\$\[(\w+)]/g;
+
+/**
+ * Checks the path contains at least one positional operator (ie ".$[element]")
+ *
+ * @param path Path with potentially a positional operator "my.$[element_for_array_filter].key"
+ * @returns true if the input path needs an arrayFilter option when using a $unset on it.
+ */
+export function isArrayFilterPath(path: string) {
+  return !!path.match(ARRAY_FILTER_OPERATION_PATTERN);
+}

--- a/src/tools/arrayFilters.ts
+++ b/src/tools/arrayFilters.ts
@@ -15,3 +15,107 @@ const ARRAY_FILTER_OPERATION_PATTERN = /\$\[(\w+)]/g;
 export function isArrayFilterPath(path: string) {
   return !!path.match(ARRAY_FILTER_OPERATION_PATTERN);
 }
+
+/**
+ * Determine whether the path corresponds to an array filter path, i.e. a path
+ * containing some positional filtered part (something with the shape $[element])
+ *
+ * If so, will check this path could lead to one of the paths in 2nd argument
+ *
+ * Examples:
+ *    > hasPathMatchingPositionalOperators(
+ *         'keys.$[element].subKey.$[element2].value',
+ *         ['keys.0.subKey.0.value']
+ *     ) => should return true
+ *
+ *    > hasPathMatchingPositionalOperators(
+ *         'keys.$[element].subKey.$[element2].value',
+ *         ['keys.0.differentSubKey']
+ *     ) => should return false
+ *
+ * @param path Path with potentially a positional operator "my.$[element_for_array_filter].key"
+ * @param pathsToMatch Array or candidate paths (without positional operator)
+ * @returns true if path is necessary
+ */
+export function hasPathMatchingPositionalOperators(
+  path: string,
+  pathsToMatch: string[],
+) {
+  if (!isArrayFilterPath(path)) {
+    return false;
+  }
+
+  // Transforms "keys.$[element].subKey" in the regex /keys.\w+.subKey/g
+  const pathRegex = new RegExp(
+    path.replace(ARRAY_FILTER_OPERATION_PATTERN, '\\w+'),
+    'g',
+  );
+
+  return pathsToMatch.some((pathToMatch) => pathRegex.test(pathToMatch));
+}
+
+/**
+ * Get the complete arrayFilter options to use when you want to do a $unset
+ * operation on the path specified in argument
+ *
+ * For example, on the path 'keys.$[element].subKey1.$[element2].value'
+ * the arrayFilter for $unset operation will need to specify the following values
+ * [
+ *   { 'element.subKey1: { $exists: 1 } },
+ *   { 'element2.value: { $exists: 1 } },
+ * ]
+ *
+ * If we don't use this arrayFilter constraints, mongo will raise an error.
+ *
+ * @param path Path with positional operators "my.$[element_for_array_filter].key"
+ * @returns arrayFilters for $unset
+ */
+export function buildArrayFiltersOptionToUnset(path: string) {
+  let positionalElementNameMatch;
+  const arrayFilters = [];
+  do {
+    positionalElementNameMatch = ARRAY_FILTER_OPERATION_PATTERN.exec(path);
+    if (positionalElementNameMatch) {
+      const subpathWithPositionalElementAndNextChild =
+        _buildSubPathWithPositionalElementAndNextChild(
+          positionalElementNameMatch[1],
+          path,
+        );
+      arrayFilters.push({
+        [subpathWithPositionalElementAndNextChild]: { $exists: true },
+      });
+    }
+  } while (positionalElementNameMatch);
+
+  return arrayFilters;
+}
+
+/**
+ * Get the key we need to put in an arrayFilter option to specify a filter when using a positional argument.
+ *
+ * For example, when update is made on 'keys.$[element].subKey1.$[element2].value'
+ * the arrayFilter for $unset operation will need to specify the following values
+ * [
+ *   { 'element.subKey1: { $exists: 1 } },
+ *   { 'element2.value: { $exists: 1 } },
+ * ]
+ *
+ * This function gets the complete path (ie 'keys.$[element].subKey1.$[element2].value')
+ * and the name of a positional argument (ie 'element' or 'element2' in this example),
+ * and returns the key to put in the options (ie 'element.subKey1' or 'element2.value')
+ *
+ * @param positionalElementName
+ * @param completePath
+ */
+function _buildSubPathWithPositionalElementAndNextChild(
+  positionalElementName: string,
+  completePath: string,
+) {
+  const matchRegexp = new RegExp(
+    `\\$\\[${positionalElementName}]\\.(\\w+)(?:\\.|$)`,
+  );
+
+  const nextChildName = matchRegexp.exec(completePath)[1];
+
+  return `${positionalElementName}.${nextChildName}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ import type { DELETE_OPERATION } from './lib/MigrationBulk';
 import { DELETE_COLLECTION } from './MongoBulkDataMigration';
 
 export type DataMigrationOptions<TSchema> = {
+  /** Array filters to use in case of a migration on nested object in arrays */
+  arrayFilters: Document[];
   /** Disable document validation temporarily on the rollback process */
   bypassRollbackValidation: boolean;
   /** Disable document validation temporarily on the update process */
@@ -40,6 +42,7 @@ export type RollbackDocument = {
 export type RollBackUpdateObject = {
   $set?: any;
   $unset?: any;
+  arrayFilters?: Document[];
 };
 
 export type MongoPipeline = object[];


### PR DESCRIPTION
closes #21
### Summary
MongoDB has introduced [`arrayfilters`](https://www.mongodb.com/docs/manual/reference/operator/update/positional-filtered/) that enable to match and update in conjunction. This is an important feature for document nested in one or several arrays.
![image](https://github.com/user-attachments/assets/25192c06-3707-46a0-893d-343c84bbd940)
- The update query can contain positional operators `$[elem_name]`
- arrayFilter will match element using those the positionals

Bulk has support for arrayFilters.
This was easy to add b4d22e3d9a776dbf906ebec8fc9cf2f854310c62

### Auto-rollback 
Has MBDM is expected to be rather magic, we will attempt to automatically come back to the initialstate, `$unset`ing what was `$set`.
We can't do reliably do a $set for the backup value as we can't search for it.

As usual, if this is over-engineered, `doRollbackAndAssertForInitialState` will find rollback is not as expected, and we can use a custom rollback.