### PR TITLE
fix(25): adds rollback handling of arrays for $unset

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.1 (2025-03-27)
+
+- Patch auto-rollback now restore unset properties - Thanks [@hugop95](https://github.com/hugop95) https://github.com/360Learning/mongo-bulk-data-migration/pull/26
+
 ## 1.5.0 (2024-12-19)
 
 - Support for `arrayFilters`

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -185,8 +185,8 @@ describe('MongoBulkDataMigration', () => {
         projection: { keys: 1 },
         update: { $unset: { keys: 1 } },
       });
-      await dataMigration.update();
 
+      await dataMigration.update();
       await dataMigration.rollback();
 
       const restoredDocuments = await collection.find().toArray();
@@ -368,7 +368,6 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-
         expect(restoredDocuments).toEqual([document]);
       });
 
@@ -384,7 +383,6 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-
         expect(restoredDocuments).toEqual([document]);
       });
 
@@ -421,7 +419,6 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-
         expect(restoredDocuments).toEqual([document]);
       });
 
@@ -437,7 +434,6 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-
         expect(restoredDocuments).toEqual([document]);
       });
 
@@ -453,7 +449,6 @@ describe('MongoBulkDataMigration', () => {
         await dataMigration.rollback();
 
         const restoredDocuments = await collection.find().toArray();
-
         expect(restoredDocuments).toEqual([document]);
       });
     });
@@ -806,8 +801,8 @@ describe('MongoBulkDataMigration', () => {
           options: { bypassRollbackValidation: true },
           update: updateQuery,
         });
-        await dataMigration.update();
 
+        await dataMigration.update();
         await dataMigration.rollback();
 
         const restoredDoc = await db
@@ -894,7 +889,6 @@ describe('MongoBulkDataMigration', () => {
         };
         await collection.insertMany([matchDocument]);
         await collection.find().toArray();
-
         const migration = new MongoBulkDataMigration<any>({
           ...DM_DEFAULT_SETUP,
           update: {
@@ -945,7 +939,6 @@ describe('MongoBulkDataMigration', () => {
         };
         await collection.insertMany([matchDocument, fullyUnmatchedDocument]);
         const insertedDocuments = await collection.find().toArray();
-
         const migration = new MongoBulkDataMigration<any>({
           ...DM_DEFAULT_SETUP,
           update: {
@@ -974,7 +967,6 @@ describe('MongoBulkDataMigration', () => {
           keys: [{ subKey1: 'match_me' }, { subKey1: 'do_not_match_me' }],
         };
         await collection.insertMany([document]);
-
         const migration = new MongoBulkDataMigration<any>({
           ...DM_DEFAULT_SETUP,
           update: {

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -441,7 +441,7 @@ describe('MongoBulkDataMigration', () => {
         expect(restoredDocuments).toEqual([document]);
       });
 
-      it('should restore a nested object value in array', async () => {
+      it('should restore a nested value in a number-indexed object', async () => {
         const document = { deep: { key: { 0: 'value' } } };
         await collection.insertMany([document]);
         const dataMigration = new MongoBulkDataMigration({

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -388,6 +388,26 @@ describe('MongoBulkDataMigration', () => {
         expect(restoredDocuments).toEqual([document]);
       });
 
+      it('should restore an array element having objects', async () => {
+        const document = { array: [ { nested: ['nestedValue'] } ] };
+        await collection.insertMany([document]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $unset: { array: 1 } }
+        });
+
+        await dataMigration.update();
+        const updateResults = await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(updateResults).toEqual({
+          ...INITIAL_BULK_INFOS,
+          nMatched: 1,
+          nModified: 1,
+        });
+        expect(restoredDocuments).toEqual([document]);
+      })
+
       it('should restore a nested object value', async () => {
         const document = { deep: { key: 'value' } };
         await collection.insertMany([document]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes https://github.com/360Learning/mongo-bulk-data-migration/issues/25

## Description

It seems that rollback computing was only handling `$set` queries and not `$unset`
https://github.com/360Learning/mongo-bulk-data-migration/blob/f4c8d9e57d071df342513e6874323783e0df01ee/src/lib/computeRollbackQuery.ts#L11-L12

## Changes

- Adds proper handling for this case.
- Renames a misleading test.
- Adds/removes newlines in some tests.

## Note

I wasn't in the mood for testing convoluted cases related to this (if all other tests still pass, we should be ok) 😅
I just focused on fixing the error mentioned in the issue. 