### PR TITLE
doc: small adjustments on documentation

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -10,7 +10,6 @@
 - Improve automatic rollback for nested paths - Thanks [@hugop95](https://github.com/hugop95) https://github.com/360Learning/mongo-bulk-data-migration/pull/19
 - Upgrade dev packages
 
-
 ## 1.4.5 (2024-10-28)
 
 - Patch 1.4.4 regression for auto rollback on nested properties

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB bulk data migration for NodeJs
 
-_Mongodb schema migration utility_
+Mongodb schema migration utility.
 
 ## About
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ new MongoBulkDataMigration({ ..., options: { ... } })
 - `dontCount` (default: false): will skip initial filter `count()` or aggregate `$count`. Logs won't print the total progression if disabled.
 - `projectionBackupFilter` (default: none): filter properties to save and auto-rollback. Necessary if your update needs virtual fields.
 - `bypassRollbackValidation` and `bypassUpdateValidation` (default: false): Will set validationLevel to "off" then to "moderate".
-- `throttle` (default: 0): amount of time to sleep between a bulk update. Use this to decrease database stress.
+- `throttle` (default: 0): amount of time in ms to sleep between a bulk update. Use this to decrease database stress.
 - `continueOnBulkWriteError` (default: false): will continue the migration on the error in a bulk.
 
 ## 📕 Advanced usages

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ new MongoBulkDataMigration<Score>({
 new MongoBulkDataMigration({ ..., options: { ... } })
 ```
 
-- `maxBulkSize` (default: 1000): Batch size of of updates to execute. 1000 is a good number. If your updated are huge, consider decreasing it to avoid running high memory. If documents are tiny, 10k might slightly improve performances on huge databases.
+- `maxBulkSize` (default: 1000): batch size of updates to execute. 1000 is a good number. If your updates are huge, consider decreasing it to avoid running high memory. If documents are tiny, 10k might slightly improve performances on huge databases.
 - `dontCount` (default: false): will skip initial filter `count()` or aggregate `$count`. Logs won't print the total progression if disabled.
 - `projectionBackupFilter` (default: none): filter properties to save and auto-rollback. Necessary if your update needs virtual fields.
 - `bypassRollbackValidation` and `bypassUpdateValidation` (default: false): Will set validationLevel to "off" then to "moderate".


### PR DESCRIPTION
### Changes

- markdown warnings
  - whitespace
  - 036-no-emphasis-as-header: https://github.com/updownpress/markdown-lint/blob/master/rules/036-no-emphasis-as-header.md
- typos
- add documentation on throttle