### PR TITLE
fix: fix nested `$set` objects not being restored correctly

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.2 (2026-02-25)
+
+- Patch nested $set restore - https://github.com/360Learning/mongo-bulk-data-migration/pull/29
+
 ## 1.5.1 (2025-03-27)
 
 - Patch auto-rollback now restore unset properties - Thanks [@hugop95](https://github.com/hugop95) https://github.com/360Learning/mongo-bulk-data-migration/pull/26

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -387,11 +387,11 @@ describe('MongoBulkDataMigration', () => {
       });
 
       it('should restore an array element having objects', async () => {
-        const document = { array: [ { nested: ['nestedValue'] } ] };
+        const document = { array: [{ nested: ['nestedValue'] }] };
         await collection.insertMany([document]);
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
-          update: { $unset: { array: 1 } }
+          update: { $unset: { array: 1 } },
         });
 
         await dataMigration.update();
@@ -404,7 +404,7 @@ describe('MongoBulkDataMigration', () => {
           nModified: 1,
         });
         expect(restoredDocuments).toEqual([document]);
-      })
+      });
 
       it('should restore a nested object value', async () => {
         const document = { deep: { key: 'value' } };

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -690,6 +690,102 @@ describe('MongoBulkDataMigration', () => {
       });
     });
 
+    describe('Setting an entire object', () => {
+      it('should restore the entire non-nested empty set object', async () => {
+        await collection.insertMany([{ a: { key: 1 } }]);
+        const insertedDocuments = await collection.find().toArray();
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $set: { a: {} } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual(insertedDocuments);
+      });
+
+      it('should restore the entire non-nested non-empty set object', async () => {
+        await collection.insertMany([{ a: { key: 1 } }]);
+        const insertedDocuments = await collection.find().toArray();
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: { $set: { a: { newKey: 1 } } },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual(insertedDocuments);
+      });
+
+      it('should restore the entire nested empty set object', async () => {
+        await collection.insertMany([
+          {
+            a: 0,
+            b: {
+              a1: 0,
+              b1: {
+                a2: 0,
+                b2: 0,
+              },
+            },
+          },
+        ]);
+        const insertedDocuments = await collection.find().toArray();
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: {
+            $set: {
+              a: 1,
+              'b.a1': 1,
+              'b.b1': {},
+            },
+          },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual(insertedDocuments);
+      });
+
+      it('should restore the entire nested non-empty set object', async () => {
+        await collection.insertMany([
+          {
+            a: 0,
+            b: {
+              a1: 0,
+              b1: {
+                a2: 0,
+                b2: 0,
+              },
+            },
+          },
+        ]);
+        const insertedDocuments = await collection.find().toArray();
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: {
+            $set: {
+              a: 1,
+              'b.a1': 1,
+              'b.b1': { c: 1 },
+            },
+          },
+        });
+
+        await dataMigration.update();
+        await dataMigration.rollback();
+
+        const restoredDocuments = await collection.find().toArray();
+        expect(restoredDocuments).toEqual(insertedDocuments);
+      });
+    });
+
     describe('Aggregate support', () => {
       it('should perform rollback for an aggregate pipeline', async () => {
         await collection.insertMany([

--- a/__tests__/lib/computeRollbackQuery.unit.ts
+++ b/__tests__/lib/computeRollbackQuery.unit.ts
@@ -1,4 +1,5 @@
 import { computeRollbackQuery } from '../../src/lib/computeRollbackQuery';
+import { ObjectId } from 'mongodb';
 
 describe('computeRollbackQuery', () => {
   it('should return an empty object if there is no operation to rollback', async () => {
@@ -11,6 +12,15 @@ describe('computeRollbackQuery', () => {
   });
 
   describe('$set', () => {
+    it('should not contain `_id`', async () => {
+      const updateQuery = { $set: { key: 'value2' } };
+      const backup = { _id: new ObjectId(), key: 'value1' };
+
+      const restoreQuery = computeRollbackQuery(updateQuery, backup);
+
+      expect(restoreQuery.$set).not.toHaveProperty('_id');
+    });
+
     describe('resulting from a $set', () => {
       it('should set back the original value', async () => {
         const updateQuery = { $set: { key: 'value2' } };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -111,6 +111,17 @@ function computeRollbackSet(
         }
       }
 
+      const setPropertyKeyStartsWith = setPropertiesDuringUpdate.find(
+        (setProperty) => key.startsWith(`${setProperty}.`),
+      );
+      if (setPropertyKeyStartsWith) {
+        rollbackSet[setPropertyKeyStartsWith] =
+          rollbackSet[setPropertyKeyStartsWith] ?? {};
+        const keyToSet = key.slice(setPropertyKeyStartsWith.length + 1);
+        rollbackSet[setPropertyKeyStartsWith][keyToSet] = value;
+        return rollbackSet;
+      }
+
       rollbackSet[key] = value;
       return rollbackSet;
     },

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -10,7 +10,11 @@ import type { Document } from 'mongodb';
 export function computeRollbackQuery(updateQuery: any, backup: any) {
   const unsetPropertiesDuringUpdate = Object.keys(updateQuery.$unset || {});
   const setPropertiesDuringUpdate = Object.keys(updateQuery.$set || {});
-  const $set = computeRollbackSet(setPropertiesDuringUpdate, unsetPropertiesDuringUpdate, backup);
+  const $set = computeRollbackSet(
+    setPropertiesDuringUpdate,
+    unsetPropertiesDuringUpdate,
+    backup,
+  );
   const $unsetWithoutPositionals = computeRollbackUnset(
     setPropertiesDuringUpdate,
     backup,
@@ -78,10 +82,8 @@ function computeRollbackSet(
     (rollbackSet, [key, value]) => {
       const parentKeyToFullyRestore = [
         ...setPropertiesDuringUpdate,
-        ...unsetPropertiesDuringUpdate
-      ].find(
-        (setOrUnsetKey) => key.startsWith(`${setOrUnsetKey}.`),
-      );
+        ...unsetPropertiesDuringUpdate,
+      ].find((setOrUnsetKey) => key.startsWith(`${setOrUnsetKey}.`));
       if (parentKeyToFullyRestore && parentKeyToFullyRestore in backup) {
         rollbackSet[parentKeyToFullyRestore] = backup[parentKeyToFullyRestore];
         return rollbackSet;

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -22,7 +22,7 @@ export function computeRollbackQuery(updateQuery: any, backup: any) {
   );
 
   const { arrayFilters, unsetAdditionalPositional } =
-    _computeArrayFilterAndUnsetWithPositionals(updateQuery, backup);
+    computeArrayFilterAndUnsetWithPositionals(updateQuery, backup);
   const $unset = {
     ...$unsetWithoutPositionals,
     ...unsetAdditionalPositional,
@@ -39,7 +39,7 @@ export function computeRollbackQuery(updateQuery: any, backup: any) {
  * If path contains a "positional argument", we'll have to add the correct
  * arrayFilters options for the $unset operation to work correctly
  */
-function _computeArrayFilterAndUnsetWithPositionals(
+function computeArrayFilterAndUnsetWithPositionals(
   updateQuery: any,
   backup: any,
 ): { arrayFilters: Document[]; unsetAdditionalPositional: any } {

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -77,8 +77,9 @@ function computeRollbackSet(
   backup: any,
 ): any {
   const flattenBackupDocument = flattenDocument(backup);
+  const flattenBackupDocumentExceptId = _.omit(flattenBackupDocument, '_id');
 
-  return Object.entries(flattenBackupDocument).reduce(
+  return Object.entries(flattenBackupDocumentExceptId).reduce(
     (rollbackSet, [key, value]) => {
       const parentKeyToFullyRestore = [
         ...setPropertiesDuringUpdate,

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -115,10 +115,11 @@ function computeRollbackSet(
         (setProperty) => key.startsWith(`${setProperty}.`),
       );
       if (setPropertyKeyStartsWith) {
-        rollbackSet[setPropertyKeyStartsWith] =
-          rollbackSet[setPropertyKeyStartsWith] ?? {};
         const keyToSet = key.slice(setPropertyKeyStartsWith.length + 1);
-        rollbackSet[setPropertyKeyStartsWith][keyToSet] = value;
+        rollbackSet[setPropertyKeyStartsWith] = {
+          ...(rollbackSet[setPropertyKeyStartsWith] ?? {}),
+          [keyToSet]: value,
+        };
         return rollbackSet;
       }
 


### PR DESCRIPTION
- Fixes #28

## Description

A `$set: { "contextKey.data": {} }` query fails when the input data is `{ contextKey: { data: { key: 1 } } }` because the rollback query results in

```ts
{
  "$set": {
    "contextKey.data.key": 1
  },
  "$unset": {
    "contextKey.data": 1
  }
}
```  

## The fix

When checking a backup key to restore when computing the rollback `$set`, the idea is to check if this flattened key  is included in the input `$set`.

In the example above, the backup would be

```ts
{
  "_id": "XXX",
  "contextKey": {
    "data": {
      "key": 1
    }
  }
}
```

The flattened backup key examined would be `contextKey.data.key`, which is "included" in `contextKey.data` present in the input `$set`.

When that happens, instead of setting `"contextKey.data.key": 1` in the rollback `$set`, we instead set `"contextKey.data": { key: 1 }` (and keep populating that object for next keys if needed).

---

The rollback `$unset` is automatically updated in that case and is now empty.

## Changes

- Fix the bug
- [BONUS] Prevent setting `_id` in rollback `$set`.