### PR TITLE
fix(35): fix rollback incorrectly restoring nested objects when $set targets a dotted path  

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0 (2026-06-19)
+
+- Patch rollback incorrectly restoring nested objects - https://github.com/360Learning/mongo-bulk-data-migration/pull/36
+
 ## 1.6.0 (2026-02-25)
 
 - Automatic resume for empty queries using `FETCH_ALL` - https://github.com/360Learning/mongo-bulk-data-migration/pull/31

--- a/__tests__/MongoBulkDataMigration.rollback.test.ts
+++ b/__tests__/MongoBulkDataMigration.rollback.test.ts
@@ -216,6 +216,25 @@ describe('MongoBulkDataMigration', () => {
       expect(restoredDocuments).toEqual(insertedDocuments);
     });
 
+    it('should restore a nested object value when the target key already existed', async () => {
+      await collection.insertOne({
+        a: { source: { x: { nested: 1 } }, target: { x: { nested: 9 } } },
+      });
+      const insertedDocuments = await collection.find().toArray();
+      const dataMigration = new MongoBulkDataMigration({
+        ...DM_DEFAULT_SETUP,
+        projection: { a: 1 },
+        query: { 'a.source': { $exists: true } },
+        update: { $set: { 'a.target': { x: { nested: 1 } } } },
+      });
+
+      await dataMigration.update();
+      await dataMigration.rollback();
+
+      const restoredDocuments = await collection.find().toArray();
+      expect(restoredDocuments).toEqual(insertedDocuments);
+    });
+
     it('should restore removed documents', async () => {
       await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
       const insertedDocuments = await collection.find().toArray();

--- a/__tests__/lib/computeRollbackQuery.unit.ts
+++ b/__tests__/lib/computeRollbackQuery.unit.ts
@@ -54,6 +54,19 @@ describe('computeRollbackQuery', () => {
           $set: { 'nested.array': ['a', 'b'] },
         });
       });
+
+      it('should set back the nested original object value when the target already existed', async () => {
+        const updateQuery = {
+          $set: { 'a.b': { channels: { email: false, teams: true } } },
+        };
+        const backup = { a: { b: { channels: { email: true } } } };
+
+        const restoreQuery = computeRollbackQuery(updateQuery, backup);
+
+        expect(restoreQuery).toEqual({
+          $set: { 'a.b': { channels: { email: true } } },
+        });
+      });
     });
 
     describe('resulting from an $unset', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/lib/computeRollbackQuery.ts
+++ b/src/lib/computeRollbackQuery.ts
@@ -115,11 +115,10 @@ function computeRollbackSet(
         (setProperty) => key.startsWith(`${setProperty}.`),
       );
       if (setPropertyKeyStartsWith) {
-        const keyToSet = key.slice(setPropertyKeyStartsWith.length + 1);
-        rollbackSet[setPropertyKeyStartsWith] = {
-          ...(rollbackSet[setPropertyKeyStartsWith] ?? {}),
-          [keyToSet]: value,
-        };
+        rollbackSet[setPropertyKeyStartsWith] = _.get(
+          backup,
+          setPropertyKeyStartsWith,
+        );
         return rollbackSet;
       }
 


### PR DESCRIPTION
- Issues:
  - Fixes https://github.com/360Learning/mongo-bulk-data-migration/issues/35 
  - https://github.com/360Learning/platform/issues/82294

This fix, alongside making sure that the platform gets the latest version of `mongo-bulk-data-migration`, should ensure that https://github.com/360Learning/platform/pull/82247#pullrequestreview-4525537020 works.

## Description

When a migration uses `$set` with a dotted path (e.g. `'a.b'`) to overwrite an existing nested object, the rollback restores that field to a wrong value.

Instead of restoring the original nested structure, it produces a flat object with a dotted key in the field name:

```js
// Expected after rollback
{ channels: { email: true } }

// Received after rollback
{ 'channels.email': true }
```

## Why it happened

During rollback, `computeRollbackQuery` needs to figure out what value to `$set` back for each key the migration changed.

For a `$set: { 'a.b': newValue }`, the backup stores the full original document (e.g. `{ a: { b: { channels: { email: true } } } }`). Internally, the backup is flattened into leaf paths for processing, so `a.b.channels.email: true` becomes one entry.

The bug was in how those leaf paths were reassembled. The code was slicing off the prefix (`a.b`) to get the remaining path (`channels.email`) and using that as a plain JS object key:

```js
// ❌
rollbackSet['a.b'] = { 'channels.email': true }
```

Instead of looking up the original value directly from the backup:

```js
// ✅
rollbackSet['a.b'] = _.get(backup, 'a.b')
```