### PR TITLE
feat(34): allow update functions to return the symbol NO_UPDATE

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.1 (2026-07-21)
+
+- Allow update functions to return the NO_UPDATE symbol
+
 ## 1.8.0 (2026-07-20)
 
 - Upgrade most dependencies

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -4,6 +4,7 @@ import { Collection, Db, Document, ObjectId, UpdateFilter } from 'mongodb';
 import { MongoBulkDataMigration, DELETE_OPERATION, FETCH_ALL } from '../src';
 import { INITIAL_BULK_INFOS } from '../src/lib/AbstractBulkOperationResults';
 import { LoggerInterface } from '../src/types';
+import { NO_UPDATE } from '../src/MongoBulkDataMigration';
 
 const COLLECTION = 'testCollection';
 const SCRIPT_ID = 'scriptId';
@@ -456,6 +457,71 @@ describe('MongoBulkDataMigration', () => {
         const rollbackCollectionSize = await rollbackCollection.count();
         expect(rollbackCollectionSize).toEqual(0);
         expect(loggerMock.warn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('NO_UPDATE update action', () => {
+      it('should not update documents when the update function returns NO_UPDATE', async () => {
+        await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
+        const insertedDocuments = await collection.find().toArray();
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: (doc) => {
+            if (doc.key === 2) {
+              return NO_UPDATE;
+            } else {
+              return { $set: { key: doc.key + 100 } };
+            }
+          },
+        });
+
+        await dataMigration.update();
+
+        const updatedDocuments = await collection
+          .find()
+          .sort({ _id: 1 })
+          .toArray();
+        expect(updatedDocuments).toEqual([
+          { _id: insertedDocuments[0]._id, key: 101 },
+          { _id: insertedDocuments[1]._id, key: 2 },
+          { _id: insertedDocuments[2]._id, key: 103 },
+        ]);
+      });
+
+      it('should not send ignored documents in batch updates', async () => {
+        await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: (doc) => {
+            if (doc.key === 2) {
+              return NO_UPDATE;
+            } else {
+              return { $set: { key: doc.key + 100 } };
+            }
+          },
+        });
+
+        await dataMigration.update();
+
+        const batchSizes = loggerMock.info.mock.calls
+          .filter(([_, msg]) => msg === 'Documents migration is successful')
+          .map(([{ nMatched, nModified }]) => ({ nMatched, nModified }));
+        expect(batchSizes).toEqual([{ nMatched: 2, nModified: 2 }]);
+      });
+
+      it('should not send any batch update if all documents are ignored', async () => {
+        await collection.insertMany([{ key: 1 }, { key: 2 }, { key: 3 }]);
+        const dataMigration = new MongoBulkDataMigration({
+          ...DM_DEFAULT_SETUP,
+          update: () => NO_UPDATE,
+        });
+
+        await dataMigration.update();
+
+        const batchSizes = loggerMock.info.mock.calls.filter(
+          ([_, msg]) => msg === 'Documents migration is successful',
+        );
+        expect(batchSizes).toEqual([]);
       });
     });
   });

--- a/__tests__/MongoBulkDataMigration.update.test.ts
+++ b/__tests__/MongoBulkDataMigration.update.test.ts
@@ -352,32 +352,35 @@ describe('MongoBulkDataMigration', () => {
     });
 
     describe('Off validation support', () => {
-      let invalidSampleDocId: ObjectId;
+      let sampleDocId: ObjectId;
 
       beforeEach(async () => {
         await db.createCollection('sampleCollection');
-        ({ insertedId: invalidSampleDocId } = await db
-          .collection('sampleCollection')
-          .insertOne({ forbiddenProp: true }));
-
         await db.command({
           collMod: 'sampleCollection',
           validator: {
             $jsonSchema: {
               bsonType: 'object',
+              properties: {
+                _id: { bsonType: 'objectId' },
+                valid_key: { bsonType: 'bool' },
+              },
+              additionalProperties: false,
             },
-            properties: {},
-            additionalProperties: false,
           },
           validationLevel: 'moderate',
           validationAction: 'error',
         });
+        ({ insertedId: sampleDocId } = await db
+          .collection('sampleCollection')
+          .insertOne({ valid_key: true }));
       });
+
       afterEach(async () => {
         await db.dropCollection('sampleCollection');
       });
 
-      it.skip('should reject update when validation is invalid', async () => {
+      it('should reject update when validation is invalid', async () => {
         const dataMigration = new MongoBulkDataMigration({
           ...DM_DEFAULT_SETUP,
           collectionName: 'sampleCollection',
@@ -387,7 +390,7 @@ describe('MongoBulkDataMigration', () => {
         const updatePromise = dataMigration.update();
 
         await expect(updatePromise).rejects.toThrow(
-          new Error('Document failed validation'),
+          'Document failed validation',
         );
       });
 
@@ -403,7 +406,7 @@ describe('MongoBulkDataMigration', () => {
 
         const updatedDoc = await db
           .collection('sampleCollection')
-          .findOne({ _id: invalidSampleDocId });
+          .findOne({ _id: sampleDocId });
         expect((updatedDoc as any).invalid_key).toEqual('update');
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@360-l/mongo-bulk-data-migration",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@360-l/mongo-bulk-data-migration",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "MongoDB bulk data migration for node scripts",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -151,19 +151,12 @@ export default class MongoBulkDataMigration<
       },
       'Starting migration UPDATE process',
     );
-    const bulkMigration = new MigrationBulk(
-      migrationCollection,
-      this.logger,
-      totalEntries,
-    );
-    const bulkBackup = new BackupBulk(
-      rollbackCollection,
-      this.logger,
-      totalEntries,
-    );
+    const bulkMigration = new MigrationBulk(migrationCollection, this.logger);
+    const bulkBackup = new BackupBulk(rollbackCollection, this.logger);
     const updatePromiseLimiter = pLimit(this.options.maxConcurrentUpdateCalls);
     let updatePromises: Promise<any>[] = [];
 
+    let treatedDocumentsCount = 0;
     let document = (await cursor.next()) as WithId<TSchema> | null;
     while (document !== null) {
       const bulkUpdateWrappedPromise = updatePromiseLimiter(
@@ -190,6 +183,18 @@ export default class MongoBulkDataMigration<
           }
         }
 
+        treatedDocumentsCount += updatePromises.length;
+        this.logger.info(
+          {
+            treatedDocumentsCount,
+            totalEntries: formattedTotalEntries,
+            progress:
+              totalEntries === NO_COUNT_AVAILABLE
+                ? 'N/A (dontCount option ON)'
+                : ((treatedDocumentsCount / totalEntries) * 100).toFixed(2),
+          },
+          'Documents migrated',
+        );
         await this.throttle();
         updatePromises = [];
       }
@@ -357,13 +362,10 @@ export default class MongoBulkDataMigration<
       { collectionName: this.collectionName, id: this.id, totalEntries },
       'Starting migration ROLLBACK process',
     );
-    const bulkRollback = new RollbackBulk(
-      collection,
-      this.logger,
-      totalEntries,
-    );
+    const bulkRollback = new RollbackBulk(collection, this.logger);
 
     await this.lowerValidationLevel('rollback');
+    let treatedDocumentsCount = 0;
     let rollbackDocument =
       (await cursor.next()) as unknown as RollbackDocument | null;
     while (rollbackDocument !== null) {
@@ -383,6 +385,16 @@ export default class MongoBulkDataMigration<
         (await cursor.next()) as unknown as RollbackDocument | null;
       if (!rollbackDocument || bulkRollback.size >= this.options.maxBulkSize) {
         await bulkRollback.execute();
+
+        treatedDocumentsCount += bulkRollback.size;
+        this.logger.info(
+          {
+            treatedDocumentsCount,
+            totalEntries,
+            progress: ((treatedDocumentsCount / totalEntries) * 100).toFixed(2),
+          },
+          'Documents rollbacked',
+        );
       }
     }
 

--- a/src/MongoBulkDataMigration.ts
+++ b/src/MongoBulkDataMigration.ts
@@ -29,6 +29,9 @@ const COLLECTION_VALIDATION_LEVEL = 'moderate';
 export const DELETE_COLLECTION = Symbol();
 /** Fetches all documents excluding already rolled-back ones, use with query:FETCH_ALL */
 export const FETCH_ALL = Symbol();
+/** Special return value for update function, when we don't need to update a given document */
+export const NO_UPDATE = Symbol();
+
 const defaultLogger = {
   info: (...args: unknown[]) => {
     if (process.env.NODE_ENV === 'test') {
@@ -272,6 +275,10 @@ export default class MongoBulkDataMigration<
       const updateQuery = _.isFunction(this.migrationInfos.update)
         ? await this.migrationInfos.update(_.cloneDeep(document))
         : this.migrationInfos.update;
+
+      if (updateQuery === NO_UPDATE) {
+        return;
+      }
 
       if (this.options.rollbackable) {
         const backupDocument = this.buildBackupDocument(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
 export { DELETE_OPERATION } from './lib/MigrationBulk';
-export { DELETE_COLLECTION, FETCH_ALL } from './MongoBulkDataMigration';
+export {
+  DELETE_COLLECTION,
+  FETCH_ALL,
+  NO_UPDATE,
+} from './MongoBulkDataMigration';
 export { default as MongoBulkDataMigration } from './MongoBulkDataMigration';

--- a/src/lib/AbstractBulkOperationResults.ts
+++ b/src/lib/AbstractBulkOperationResults.ts
@@ -42,7 +42,6 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
   protected readonly collection: Collection<TSchema>;
   protected readonly results: BulkOperationResult;
   protected bulk: UnorderedBulkOperation;
-  protected totalBulkOps: number;
   protected readonly totalOperations: number | typeof NO_COUNT_AVAILABLE;
   protected readonly logger: LoggerInterface;
 
@@ -55,14 +54,13 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
     this.totalOperations = totalOperations;
     this.logger = logger;
     this.bulk = this.collection.initializeUnorderedBulkOp();
-    this.totalBulkOps = 0;
     this.results = _.cloneDeep(INITIAL_BULK_INFOS);
   }
 
   abstract logExecutionStatus(executionResults: BulkOperationResult): this;
 
   get size() {
-    return this.totalBulkOps;
+    return this.bulk.length;
   }
 
   get progress(): number {
@@ -79,7 +77,7 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
   }
 
   public async execute(continueOnBulkWriteError = false): Promise<this> {
-    if (this.totalBulkOps === 0) {
+    if (this.bulk.length === 0) {
       return this;
     }
 
@@ -112,7 +110,6 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
     this.logExecutionStatus(resultPartial);
 
     this.bulk = this.collection.initializeUnorderedBulkOp();
-    this.totalBulkOps = 0;
 
     return this;
   }

--- a/src/lib/AbstractBulkOperationResults.ts
+++ b/src/lib/AbstractBulkOperationResults.ts
@@ -42,16 +42,10 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
   protected readonly collection: Collection<TSchema>;
   protected readonly results: BulkOperationResult;
   protected bulk: UnorderedBulkOperation;
-  protected readonly totalOperations: number | typeof NO_COUNT_AVAILABLE;
   protected readonly logger: LoggerInterface;
 
-  constructor(
-    collection: Collection<TSchema>,
-    logger: LoggerInterface,
-    totalOperations: number,
-  ) {
+  constructor(collection: Collection<TSchema>, logger: LoggerInterface) {
     this.collection = collection;
-    this.totalOperations = totalOperations;
     this.logger = logger;
     this.bulk = this.collection.initializeUnorderedBulkOp();
     this.results = _.cloneDeep(INITIAL_BULK_INFOS);
@@ -61,19 +55,6 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
 
   get size() {
     return this.bulk.length;
-  }
-
-  get progress(): number {
-    if (this.totalOperations === NO_COUNT_AVAILABLE) {
-      return Infinity;
-    }
-    return (this.totalOperationsDone / this.totalOperations) * 100;
-  }
-
-  get totalOperationsDone() {
-    return (
-      this.results.nMatched + this.results.nUpserted + this.results.nInserted
-    );
   }
 
   public async execute(continueOnBulkWriteError = false): Promise<this> {
@@ -141,25 +122,11 @@ export abstract class AbstractBulkOperationResults<TSchema extends Document> {
   }
 
   protected buildLogObject(executionResults: BulkOperationResult) {
-    const usefulLogEntries = Object.entries(executionResults)
-      .filter(([key]) => !['insertedIds', 'upserted'].includes(key))
-      .filter(([, value]) => !_.isEmpty(value) || value > 0);
-    const progress = this.progress;
-    const formattedPercent = Number.isFinite(progress)
-      ? progress.toFixed(2)
-      : 'N/A';
-
-    return {
-      ...Object.fromEntries(usefulLogEntries),
-      progress: {
-        totalOperationsDone: this.totalOperationsDone,
-        estimatedTotalOperations:
-          this.totalOperations === NO_COUNT_AVAILABLE
-            ? 'N/A'
-            : this.totalOperations,
-        percent: formattedPercent,
-      },
-    };
+    return Object.fromEntries(
+      Object.entries(executionResults)
+        .filter(([key]) => !['insertedIds', 'upserted'].includes(key))
+        .filter(([, value]) => !_.isEmpty(value) || value > 0),
+    );
   }
 }
 

--- a/src/lib/BackupBulk.ts
+++ b/src/lib/BackupBulk.ts
@@ -18,7 +18,6 @@ export class BackupBulk<
     document: WithId<TSchema>,
     rollbackDocument: any,
   ): this {
-    this.totalBulkOps++;
     this.bulk
       .find({ _id: document._id })
       .upsert()

--- a/src/lib/MigrationBulk.ts
+++ b/src/lib/MigrationBulk.ts
@@ -32,8 +32,6 @@ export class MigrationBulk<
     objectId: ObjectId,
     arrayFilters: Document[],
   ): this {
-    this.totalBulkOps++;
-
     if (arrayFilters.length === 0) {
       this.bulk.find({ _id: objectId }).update(updateQuery);
     } else {
@@ -47,7 +45,6 @@ export class MigrationBulk<
   }
 
   public addRemoveOperation(objectId: ObjectId): this {
-    this.totalBulkOps++;
     this.bulk.find({ _id: objectId }).deleteOne();
     return this;
   }

--- a/src/lib/RollbackBulk.ts
+++ b/src/lib/RollbackBulk.ts
@@ -19,8 +19,6 @@ export class RollbackBulk<
     objectId: ObjectId,
     arrayFilters: Document[],
   ): this {
-    this.totalBulkOps++;
-
     if (arrayFilters.length === 0) {
       this.bulk.find({ _id: objectId }).update(operation);
     } else {
@@ -34,7 +32,6 @@ export class RollbackBulk<
   }
 
   public addRollbackFullDocumentOperation(document: any): this {
-    this.totalBulkOps++;
     this.bulk.insert(document);
     return this;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import type {
 } from 'mongodb';
 import type { DELETE_OPERATION } from './lib/MigrationBulk';
 import { DELETE_COLLECTION, FETCH_ALL } from './MongoBulkDataMigration';
+import type { NO_UPDATE } from './MongoBulkDataMigration';
 
 export type DataMigrationOptions<TSchema> = {
   /** Array filters to use in case of a migration on nested object in arrays */
@@ -58,7 +59,10 @@ export type MigrationInfos<TSchema extends Document> = {
     | typeof DELETE_OPERATION
     | ((
         arg: TSchema | UpdateFilter<TSchema>,
-      ) => Promise<UpdateFilter<TSchema>> | UpdateFilter<TSchema>);
+      ) =>
+        | Promise<UpdateFilter<TSchema> | typeof NO_UPDATE>
+        | UpdateFilter<TSchema>
+        | typeof NO_UPDATE);
 };
 
 export type DataMigrationConfig<


### PR DESCRIPTION
# Context

* The `update` option of `MongoBulkDataMigration` can be a function
  * called for each document to update
  * returning the desired document update (`{ $set: xxx }`)
* We can detect only at runtime that a document doesn't really need to be updated
  * e.g., the update function requests another collection to decide what should be updated
* No need to send a no-op request to MongoDB in this case!

# Changes

- commits 1 and 2: boyscoutings
  - #37 was not enough, I've found more opportunities for boyscouting
- commits 3 and 4: allow update functions to return a new `NO_UPDATE` symbol
  - note that the progress logging was produced when calling bulk updates
  - but now, bulk updates don't necessarily hold all fetched documents (ignored ones are skipped)
  - so the progress logging is moved higher in the document loop
- commit 5: bump new version


